### PR TITLE
Warn user if directory not found.

### DIFF
--- a/cc.openframeworks.plugin/src/cc/openframeworks/plugin/wizards/SelectAddonPage.java
+++ b/cc.openframeworks.plugin/src/cc/openframeworks/plugin/wizards/SelectAddonPage.java
@@ -102,34 +102,38 @@ public class SelectAddonPage extends WizardPage{
 		String ofRoot = Activator.getDefault().getPreferenceStore().getString("OF_ROOT");
 		if(ofRoot!=null && ofRoot!=""){
 		    File addonsFolder = new File(ofRoot + "/addons");
-		    ArrayList<String> addonsNames = new ArrayList<String>();
-		    for(File f:addonsFolder.listFiles()){
-		    	if(f.isDirectory() && f.getName().startsWith("ofx")){
-		    		addonsNames.add(f.getName());
-		    	}
-		    } 
-		    Collections.sort(addonsNames, new Comparator<String>() {
-				@Override
-				public int compare(String o1, String o2) {
-					return o1.compareTo(o2);
-				}
-			});
+			if (!f.exists()) {
+				setMessage("Directory \""+ofRoot+"/addons\" not found, please check openFrameworks path set in Windows > Preferences > openFrameworks",WizardPage.WARNING);
+			} else {
+			    ArrayList<String> addonsNames = new ArrayList<String>();
+			    for(File f:addonsFolder.listFiles()){
+			    	if(f.isDirectory() && f.getName().startsWith("ofx")){
+			    		addonsNames.add(f.getName());
+			    	}
+			    } 
+			    Collections.sort(addonsNames, new Comparator<String>() {
+					@Override
+					public int compare(String o1, String o2) {
+						return o1.compareTo(o2);
+					}
+				});
 
-		    for(String f: addonsNames){
-		    	if(invalidAddons.contains(f)){
-		    		continue;
-		    	}
-		    	TreeItem item;
-		    	if(officialAddons.contains(f)){
-		    		item = new TreeItem(officialAddonsList, SWT.NONE);
-		    	}else{
-		    		item = new TreeItem(addonsList, SWT.NONE);
-		    	}
-		    	item.setText(f);
-	    		if(currentAddons.contains(f)){
-	    			item.setChecked(true);
-	    		}
-		    }
+			    for(String f: addonsNames){
+			    	if(invalidAddons.contains(f)){
+			    		continue;
+			    	}
+			    	TreeItem item;
+			    	if(officialAddons.contains(f)){
+			    		item = new TreeItem(officialAddonsList, SWT.NONE);
+			    	}else{
+			    		item = new TreeItem(addonsList, SWT.NONE);
+			    	}
+			    	item.setText(f);
+		    		if(currentAddons.contains(f)){
+		    			item.setChecked(true);
+		    		}
+			    }
+			}
 		}else{
 			setMessage("Can't parse avaliable addons until openFrameworks path is set in Windows > Preferences > openFrameworks",WizardPage.WARNING);
 		}


### PR DESCRIPTION
Hi!

When trying out Eclipse (cause Code Blocks didn't work out any more for me ;) ) I was wondering why the plugin didn't work (following [these](https://vimeo.com/143111040) instructions).

Found this in the logs
```bash
!ENTRY org.eclipse.ui 4 0 2016-11-14 17:37:06.572
!MESSAGE Unhandled event loop exception
!STACK 0
java.lang.NullPointerException
	at cc.openframeworks.plugin.wizards.SelectAddonPage.createControl(SelectAddonPage.java:106)
	at org.eclipse.jface.wizard.WizardDialog.updateForPage(WizardDialog.java:1202)
	[...]
```

so I configured the path run...
My PR should show a warning message to the user when the path is not found.

Disclaimer: I didn't get the plugin to work with my changes. I hope I can give that another try later on.